### PR TITLE
Activity id is not required by get()

### DIFF
--- a/lib/activities.js
+++ b/lib/activities.js
@@ -39,10 +39,8 @@ activities.get = function(args,done) {
         , err = null
         , qs = util.getQS(_qsAllowedProps,args);
 
-    //require activity id
     if(typeof args.id === 'undefined') {
-        err = {msg:'args must include an activity id'};
-        return done(err);
+        args.id = "";
     }
 
     endpoint += args.id + '?' + qs;


### PR DESCRIPTION
If not given, get() returns all activities within the other query params
